### PR TITLE
basics: fixup case fallthrough

### DIFF
--- a/basics.cpp
+++ b/basics.cpp
@@ -301,13 +301,13 @@ static int spifns_sequence_setvar(const char *szName, const char *szValue) {
     for (unsigned int i=0; i<(sizeof(g_pVarList)/sizeof(*g_pVarList)); i++) {
         if (stricmp(szName,g_pVarList[i].szName)==0) {
             switch (i) {
-            case VARLIST_SPISPORT:{
+            case VARLIST_SPISPORT:
                 if (!spifns_sequence_setvar_spiport(nValue)) {
                     const char szError[]="Couldn't find SPI port";
                     memcpy(g_szErrorString,szError,sizeof(szError));
                     return 1;
                 }
-                                  }break;
+                break;
             case VARLIST_SPICLOCK:
                 if (nValue <= 0)
                     return 1; //ERROR!
@@ -409,6 +409,7 @@ static int spifns_sequence_setvar(const char *szName, const char *szValue) {
                     }
                     spi_set_pinout(pinout);
                 }
+                break;
             case VARLIST_FTDI_INTERFACE:
                 if (spi_set_interface(szValue) < 0) {
                     const char szError[]="Invalid channel specified in FTDI_INTERFACE";


### PR DESCRIPTION
Thank you @lorf for the library.
Here's a minor fix that allows to take more options.


For reference, with an FT2232HL (hooked as per http://www.ftdichip.com/Support/Documents/AppNotes/AN_114_FTDI_Hi_Speed_USB_To_SPI_Example.pdf or also on my dear Bus Blaster v2):
```
export FTDI_INTERFACE=A FTDI_PINOUT=hwspi
BlueFlash.exe
BlueFlashCmd.exe -usb 1 identify
```